### PR TITLE
added support for start and end indices

### DIFF
--- a/lm_eval/metrics/fuzzy_list_comparison.py
+++ b/lm_eval/metrics/fuzzy_list_comparison.py
@@ -60,3 +60,26 @@ def precision(ref_list, pred_list):
 
 def recall(ref_list, pred_list):
     return len(ref_list), float(len([x for x in ref_list if x in pred_list]))
+
+
+if __name__ == '__main__':
+    import json
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output_file')
+    args = parser.parse_args()
+
+    refs, preds = [], []
+    with open(args.output_file) as fp:
+        for line in fp:
+            dict_output = json.loads(line)
+            preds.append(dict_output['pred'])
+            assert len(dict_output['target']) == 1
+            refs.append(dict_output['target'])
+    p = score(precision, list(zip(refs, preds)))
+    r = score(recall, list(zip(refs, preds)))
+    f = fscore(precision, recall, list(zip(refs, preds)))
+    print('Precision  =', p)
+    print('Recall  =', r)
+    print('F-score  =', f)
+    

--- a/main.py
+++ b/main.py
@@ -28,6 +28,18 @@ def parse_args():
         "`key1=value1,key2=value2`, with no spaces",
     )
     parser.add_argument(
+        "--idx_start",
+        type=int,
+        default=None,
+        help="Starting index for slicing the dataset",
+    )
+    parser.add_argument(
+        "--idx_end",
+        type=int,
+        default=None,
+        help="Ending index for slicing the dataset",
+    )
+    parser.add_argument(
         "--task_name",
         required=True,
         help="Name of the task to use as found "
@@ -195,6 +207,8 @@ def main():
         bootstrap_iters=args.bootstrap_iters,
         seed=args.seed,
         limit=args.limit,
+        idx_start=args.idx_start,
+        idx_end=args.idx_end,
     )
     if args.no_tracking:
         results = evaluator.cli_evaluate(**evaluate_args)


### PR DESCRIPTION
This version includes the possibility to specify start and end indices (`--idx_start` and `--idx_end`) in the dataset in order to evaluate only a subset of the data. It makes sure that given a random seed, the selection of few-shot examples is done in such a way that the same examples are selected as those that would have been selected had the whole dataset been evaluated.

It also includes a modification to the `fuzzy_list_comparison.py` file to allow the evaluation of example files outside of lm_eval harness (the addition of a `__main__` in the file).